### PR TITLE
Polish animations and overall feel across the site

### DIFF
--- a/src/app/(site)/building/page.tsx
+++ b/src/app/(site)/building/page.tsx
@@ -196,7 +196,11 @@ export default function BuildingPage() {
 					{companies.map((company) => (
 						<div
 							key={company.id}
-							className={`bg-[rgba(var(--color-foreground),0.03)] border border-[rgba(var(--color-border),0.08)] hover:shadow-md rounded-xl overflow-hidden transition-all duration-300 group`}
+							className="bg-[rgba(var(--color-foreground),0.03)] border border-[rgba(var(--color-border),0.08)] hover:shadow-md rounded-xl overflow-hidden group"
+							style={{
+								transition:
+									"border-color var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out)",
+							}}
 						>
 							<div className="flex flex-col md:flex-row">
 								<div className="md:w-2/5 bg-[rgb(var(--color-background))] flex items-center justify-center p-8 rounded-xl overflow-hidden">
@@ -206,14 +210,15 @@ export default function BuildingPage() {
 												src={company.image}
 												alt={company.title}
 												fill
-												className="object-contain transition-transform duration-500 group-hover:scale-105 rounded-xl"
+												className="object-contain group-hover:scale-[1.04] rounded-xl"
+												style={{ transition: "transform var(--dur-slow) var(--ease-out)" }}
 												priority
 											/>
 										</div>
 									</div>
 								</div>
 								<div className="p-8 md:w-3/5">
-									<h3 className="text-2xl font-bold text-[rgba(var(--color-foreground),0.95)] mb-2 transition-colors">
+									<h3 className="text-2xl font-bold text-[rgba(var(--color-foreground),0.95)] mb-2">
 										{company.title}
 									</h3>
 									<p className="text-[rgb(var(--color-accent))] font-medium mb-3">
@@ -275,7 +280,11 @@ export default function BuildingPage() {
 					{projects.map((project) => (
 						<div
 							key={project.id}
-							className={`bg-[rgba(var(--color-foreground),0.03)] border border-[rgba(var(--color-border),0.08)] hover:shadow-md rounded-xl overflow-hidden transition-all duration-300 group`}
+							className="bg-[rgba(var(--color-foreground),0.03)] border border-[rgba(var(--color-border),0.08)] hover:shadow-md rounded-xl overflow-hidden group"
+							style={{
+								transition:
+									"border-color var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out)",
+							}}
 						>
 							<div className="flex flex-col md:flex-row">
 								<div className="md:w-2/5 bg-[rgb(var(--color-background))] flex items-center justify-center p-8 rounded-xl overflow-hidden">
@@ -296,7 +305,8 @@ export default function BuildingPage() {
 														src={project.image}
 														alt={project.title}
 														fill
-														className="object-contain transition-transform duration-500 group-hover:scale-105 rounded-xl"
+														className="object-contain group-hover:scale-[1.04] rounded-xl"
+														style={{ transition: "transform var(--dur-slow) var(--ease-out)" }}
 													/>
 												</Link>
 											) : (
@@ -304,7 +314,8 @@ export default function BuildingPage() {
 													src={project.image}
 													alt={project.title}
 													fill
-													className="object-contain transition-transform duration-500 group-hover:scale-105 rounded-xl"
+													className="object-contain group-hover:scale-[1.04] rounded-xl"
+													style={{ transition: "transform var(--dur-slow) var(--ease-out)" }}
 												/>
 											)}
 										</div>
@@ -320,7 +331,8 @@ export default function BuildingPage() {
 											}
 										>
 											<h2
-												className="text-2xl font-bold text-[rgba(var(--color-foreground),0.9)] mb-2 group-hover:text-[rgb(var(--color-accent))] transition-colors"
+												className="text-2xl font-bold text-[rgba(var(--color-foreground),0.9)] mb-2 group-hover:text-[rgb(var(--color-accent))]"
+												style={{ transition: "color var(--dur-base) var(--ease-out)" }}
 											>
 												{project.title}
 											</h2>

--- a/src/app/(site)/investing/page.tsx
+++ b/src/app/(site)/investing/page.tsx
@@ -10,11 +10,20 @@ function getRandomQuote() {
 }
 
 export default function InvestingPage() {
+	// Render an empty quote until mount, then fade the random pick in.
+	// Avoids the default→real swap flicker that previously fired on every navigation.
 	const [randomQuote, setRandomQuote] = useState(quotes[0])
+	const [quoteVisible, setQuoteVisible] = useState(false)
 	const pathname = usePathname()
 
 	useEffect(() => {
-		setRandomQuote(getRandomQuote())
+		setQuoteVisible(false)
+		// Small delay so the fade-in is perceptible on rapid navigations.
+		const t = setTimeout(() => {
+			setRandomQuote(getRandomQuote())
+			setQuoteVisible(true)
+		}, 40)
+		return () => clearTimeout(t)
 	}, [pathname])
 
 	return (
@@ -115,7 +124,14 @@ export default function InvestingPage() {
 			<div className="mb-16">
 				<div className="max-w-3xl mx-auto">
 					<div className="relative rounded-lg py-6 px-8 bg-[rgba(var(--color-foreground),0.03)]">
-						<blockquote className="relative z-10 pl-4">
+						<blockquote
+							className="relative z-10 pl-4"
+							style={{
+								opacity: quoteVisible ? 1 : 0,
+								transition:
+									"opacity var(--dur-slow) var(--ease-out)",
+							}}
+						>
 							<div className="absolute top-0 left-0 w-[2px] h-full bg-[rgba(var(--color-accent),0.4)]"></div>
 							<p className="italic text-lg md:text-xl text-[rgba(var(--color-foreground),0.85)] leading-relaxed pl-4">
 								&ldquo;{randomQuote.text}&rdquo;

--- a/src/app/(site)/thinking/page.tsx
+++ b/src/app/(site)/thinking/page.tsx
@@ -30,7 +30,11 @@ export default async function ThinkingPage() {
 					{posts.map((post) => (
 						<article
 							key={post.id}
-							className="flex flex-col overflow-hidden rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 bg-[rgba(var(--color-background-alt),0.5)] border border-[rgba(var(--color-foreground),0.1)]"
+							className="flex flex-col overflow-hidden rounded-xl shadow-lg hover:shadow-xl bg-[rgba(var(--color-background-alt),0.5)] border border-[rgba(var(--color-foreground),0.1)]"
+							style={{
+								transition:
+									"box-shadow var(--dur-base) var(--ease-out), border-color var(--dur-base) var(--ease-out)",
+							}}
 						>
 							<div className="group">
 								{post.featured_image ? (
@@ -46,7 +50,8 @@ export default async function ThinkingPage() {
 											fill
 											priority
 											sizes="(max-width: 768px) 100vw, 800px"
-											className="object-cover group-hover:scale-105 transition-transform duration-500"
+											className="object-cover group-hover:scale-[1.04]"
+											style={{ transition: "transform var(--dur-slow) var(--ease-out)" }}
 											unoptimized={post.featured_image.includes("supabase")}
 										/>
 									</Link>
@@ -57,7 +62,8 @@ export default async function ThinkingPage() {
 									<div className="flex items-center mb-3">
 										<Link
 											href={`/thinking/about/${post.category.toLowerCase()}`}
-											className="text-xs font-medium px-2.5 py-1 rounded-full bg-[rgba(var(--color-violet),0.1)] text-[rgba(var(--color-violet),0.8)] hover:bg-[rgba(var(--color-violet),0.2)] transition-colors"
+											className="text-xs font-medium px-2.5 py-1 rounded-full bg-[rgba(var(--color-violet),0.1)] text-[rgba(var(--color-violet),0.8)] hover:bg-[rgba(var(--color-violet),0.2)]"
+											style={{ transition: "background-color var(--dur-base) var(--ease-out)" }}
 										>
 											{post.category}
 										</Link>
@@ -74,17 +80,24 @@ export default async function ThinkingPage() {
 										}`}
 										className="block"
 									>
-										<h2 className="text-2xl font-bold text-[rgba(var(--color-foreground),0.9)] mb-3 group-hover:text-[rgb(var(--color-violet))] transition-colors">
+										<h2
+											className="text-2xl font-bold text-[rgba(var(--color-foreground),0.9)] mb-3 group-hover:text-[rgb(var(--color-violet))]"
+											style={{ transition: "color var(--dur-slow) var(--ease-out)" }}
+										>
 											{post.title}
 										</h2>
 										<p className="text-[rgba(var(--color-foreground),0.7)] mb-4">
 											{post.excerpt}
 										</p>
-										<div className="text-[rgb(var(--color-accent))] hover:text-[rgb(var(--color-accent-secondary))] transition-colors inline-flex items-center">
+										<div
+											className="text-[rgb(var(--color-accent))] hover:text-[rgb(var(--color-accent-secondary))] inline-flex items-center"
+											style={{ transition: "color var(--dur-base) var(--ease-out)" }}
+										>
 											Read more
 											<svg
 												xmlns="http://www.w3.org/2000/svg"
-												className="h-5 w-5 ml-1 group-hover:translate-x-1 transition-transform"
+												className="h-5 w-5 ml-1 group-hover:translate-x-1"
+												style={{ transition: "transform var(--dur-slow) var(--ease-out)" }}
 												viewBox="0 0 20 20"
 												fill="currentColor"
 											>

--- a/src/app/admin/admin.css
+++ b/src/app/admin/admin.css
@@ -65,7 +65,9 @@
 	padding: 0.75rem 1rem;
 	color: var(--admin-text-secondary);
 	text-decoration: none;
-	transition: all 0.2s ease;
+	transition:
+		background-color var(--dur-fast) var(--ease-out),
+		color var(--dur-fast) var(--ease-out);
 	border-radius: 0.375rem;
 	margin: 0.25rem 0.75rem;
 	text-align: left;
@@ -102,7 +104,9 @@
 	color: var(--admin-text-secondary);
 	text-decoration: none;
 	border-radius: 0.375rem;
-	transition: all 0.2s ease;
+	transition:
+		background-color var(--dur-fast) var(--ease-out),
+		color var(--dur-fast) var(--ease-out);
 	margin-bottom: 0.5rem;
 	text-align: left;
 }
@@ -147,7 +151,10 @@
 	padding: 0.75rem 1.5rem;
 	border-radius: 0.5rem;
 	font-weight: 500;
-	transition: all 0.2s ease;
+	transition:
+		background-color var(--dur-base) var(--ease-out),
+		box-shadow var(--dur-base) var(--ease-out),
+		transform var(--dur-press) var(--ease-press);
 	display: inline-flex;
 	align-items: center;
 	gap: 0.5rem;
@@ -161,6 +168,11 @@
 	box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
 }
 
+.admin-layout .bg-green-600:active {
+	transform: translateY(0) scale(0.97);
+	transition-duration: 80ms;
+}
+
 /* Admin button variants - MATCHING SITE DESIGN */
 .admin-layout .btn-primary {
 	background-color: rgba(var(--color-violet), 0.1);
@@ -169,7 +181,11 @@
 	color: white;
 	padding: 0.75rem 1.5rem;
 	font-weight: 500;
-	transition: all 300ms;
+	transition:
+		background-color var(--dur-base) var(--ease-out),
+		border-color var(--dur-base) var(--ease-out),
+		box-shadow var(--dur-base) var(--ease-out),
+		transform var(--dur-press) var(--ease-press);
 	position: relative;
 	overflow: hidden;
 	display: inline-flex;
@@ -185,13 +201,21 @@
 	box-shadow: 0 0 15px rgba(var(--color-violet), 0.3);
 }
 
+.admin-layout .btn-primary:active {
+	transform: scale(0.97);
+	transition-duration: 80ms;
+}
+
 .admin-layout .btn-secondary {
 	background-color: rgba(255, 255, 255, 0.1);
 	color: var(--admin-text-primary);
 	padding: 0.5rem 1rem;
 	border-radius: 0.375rem;
 	font-weight: 500;
-	transition: all 0.2s ease;
+	transition:
+		background-color var(--dur-fast) var(--ease-out),
+		border-color var(--dur-fast) var(--ease-out),
+		transform var(--dur-press) var(--ease-press);
 	display: inline-flex;
 	align-items: center;
 	gap: 0.5rem;
@@ -205,6 +229,11 @@
 	border-color: rgba(255, 255, 255, 0.2);
 }
 
+.admin-layout .btn-secondary:active {
+	transform: scale(0.97);
+	transition-duration: 80ms;
+}
+
 /* Admin neon button variants to match site design */
 .admin-layout .neon-button-violet {
 	padding: 0.75rem 1.5rem;
@@ -213,7 +242,11 @@
 	border-radius: 0.5rem;
 	color: white;
 	font-weight: 500;
-	transition: all 300ms;
+	transition:
+		background-color var(--dur-base) var(--ease-out),
+		border-color var(--dur-base) var(--ease-out),
+		box-shadow var(--dur-base) var(--ease-out),
+		transform var(--dur-press) var(--ease-press);
 	position: relative;
 	overflow: hidden;
 	min-width: 160px;
@@ -238,7 +271,11 @@
 	border-radius: 0.5rem;
 	color: white;
 	font-weight: 500;
-	transition: all 300ms;
+	transition:
+		background-color var(--dur-base) var(--ease-out),
+		border-color var(--dur-base) var(--ease-out),
+		box-shadow var(--dur-base) var(--ease-out),
+		transform var(--dur-press) var(--ease-press);
 	position: relative;
 	overflow: hidden;
 	min-width: 160px;
@@ -263,7 +300,11 @@
 	border-radius: 0.5rem;
 	color: white;
 	font-weight: 500;
-	transition: all 300ms;
+	transition:
+		background-color var(--dur-base) var(--ease-out),
+		border-color var(--dur-base) var(--ease-out),
+		box-shadow var(--dur-base) var(--ease-out),
+		transform var(--dur-press) var(--ease-press);
 	position: relative;
 	overflow: hidden;
 	min-width: 160px;
@@ -285,7 +326,7 @@
 .admin-layout a {
 	color: var(--admin-accent);
 	text-decoration: none;
-	transition: color 0.2s ease;
+	transition: color var(--dur-fast) var(--ease-out);
 }
 
 .admin-layout a:hover {
@@ -400,6 +441,10 @@
 	color: var(--admin-text-secondary);
 }
 
+.admin-layout .posts-table tbody tr {
+	transition: background-color 120ms var(--ease-out);
+}
+
 .admin-layout .posts-table tr:hover {
 	background-color: rgba(255, 255, 255, 0.02);
 }
@@ -446,7 +491,9 @@
 	border: 1px solid rgba(255, 255, 255, 0.1);
 	border-radius: 0.5rem;
 	margin-bottom: 0;
-	transition: all 0.2s ease;
+	transition:
+		border-color var(--dur-fast) var(--ease-out),
+		box-shadow var(--dur-fast) var(--ease-out);
 }
 
 .admin-layout .contacts-list .contact-card:hover {
@@ -495,12 +542,20 @@
 	font-weight: 500;
 	border: none;
 	cursor: pointer;
-	transition: all 0.2s ease;
+	transition:
+		background-color var(--dur-fast) var(--ease-out),
+		color var(--dur-fast) var(--ease-out),
+		transform var(--dur-press) var(--ease-press);
 }
 
 .admin-layout .contacts-list .btn-mark-read:hover {
 	background-color: #0891b2;
 	transform: translateY(-1px);
+}
+
+.admin-layout .contacts-list .btn-mark-read:active {
+	transform: translateY(0) scale(0.97);
+	transition-duration: 80ms;
 }
 
 .admin-layout .contacts-list .btn-mark-read.read {
@@ -539,7 +594,9 @@
 	background: none;
 	color: var(--admin-text-secondary);
 	cursor: pointer;
-	transition: all 0.2s ease;
+	transition:
+		color var(--dur-fast) var(--ease-out),
+		border-color var(--dur-fast) var(--ease-out);
 	border-bottom: 2px solid transparent;
 	font-weight: 500;
 }
@@ -568,7 +625,9 @@
 	padding: 0.75rem 1rem;
 	border-radius: 0.5rem;
 	font-size: 0.875rem;
-	transition: all 0.2s ease;
+	transition:
+		border-color var(--dur-fast) var(--ease-out),
+		box-shadow var(--dur-fast) var(--ease-out);
 }
 
 .admin-layout .search-controls input:focus,
@@ -586,7 +645,7 @@
 @media (max-width: 768px) {
 	.admin-navigation {
 		transform: translateX(-100%);
-		transition: transform 0.3s ease;
+		transition: transform 280ms var(--ease-drawer);
 	}
 
 	.admin-navigation.open {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,6 +31,37 @@
 	--color-emerald: var(--color-accent);
 	--color-pink: var(--color-accent-secondary);
 	--color-orange: var(--color-accent-secondary);
+
+	/* Motion tokens — every animation in the system pulls from these.
+	   Built on Emil Kowalski's design-engineering philosophy:
+	   strong custom curves, durations under 300ms for UI. */
+	--ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+	--ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+	--ease-press: cubic-bezier(0.4, 0, 0.2, 1);
+	--ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+
+	--dur-press: 140ms;
+	--dur-fast: 180ms;
+	--dur-base: 220ms;
+	--dur-slow: 320ms;
+	--dur-hero: 480ms;
+}
+
+/* ============================================
+   Reduced Motion — global accessibility baseline.
+   Honors prefers-reduced-motion by collapsing all animation
+   and transition durations. Opacity/color transitions still
+   feel right at near-zero; transform-based motion disappears.
+   ============================================ */
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
 }
 
 /* ============================================
@@ -87,6 +118,11 @@
 		0%, 100% { transform: translateY(0px) rotate(0deg); }
 		50% { transform: translateY(-20px) rotate(3deg); }
 	}
+
+	/* Terminal cursor — `steps(2)` makes a clean on/off blink instead of a fade. */
+	@keyframes terminal-blink {
+		50% { opacity: 0; }
+	}
 }
 
 /* ============================================
@@ -99,6 +135,21 @@
 
 	.animate-hex-glow {
 		animation: hex-glow 3s ease infinite;
+	}
+
+	/* Hero entrance — fade up 8px in 480ms with the system ease-out.
+	   `both` so the element keeps its from-state until its delay fires. */
+	.hero-stagger {
+		opacity: 0;
+		transform: translateY(8px);
+		animation: hero-stagger var(--dur-hero) var(--ease-out) both;
+	}
+
+	@keyframes hero-stagger {
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
 	}
 }
 
@@ -190,7 +241,9 @@
 		font-family: var(--font-display, 'Playfair Display', Georgia, serif);
 	}
 
-	/* Primary button — amber bg, navy text, monospace */
+	/* Primary button — amber bg, navy text, monospace.
+	   Carries a baseline shadow so hover *grows* it rather than
+	   summoning one from nothing. Press feedback via :active. */
 	.btn-primary {
 		padding: 0.75rem 1.5rem;
 		background-color: rgb(var(--color-accent));
@@ -201,15 +254,27 @@
 		font-weight: 500;
 		font-size: 13px;
 		letter-spacing: 0.05em;
-		transition: all 200ms ease;
+		box-shadow: 0 1px 3px rgba(var(--color-accent), 0.12);
+		transition:
+			background-color var(--dur-base) var(--ease-out),
+			box-shadow var(--dur-base) var(--ease-out),
+			transform var(--dur-press) var(--ease-press),
+			opacity var(--dur-base) var(--ease-out);
 		position: relative;
 		overflow: hidden;
 	}
 
-	.btn-primary:hover {
-		opacity: 0.9;
-		box-shadow: 0 2px 8px rgba(var(--color-accent), 0.3);
-		transform: translateY(-1px);
+	@media (hover: hover) and (pointer: fine) {
+		.btn-primary:hover {
+			opacity: 0.92;
+			box-shadow: 0 4px 14px -4px rgba(var(--color-accent), 0.4);
+			transform: translateY(-1px);
+		}
+	}
+
+	.btn-primary:active {
+		transform: translateY(0) scale(0.97);
+		transition-duration: 80ms;
 	}
 
 	/* Secondary button — outlined amber, monospace */
@@ -223,17 +288,28 @@
 		font-weight: 400;
 		font-size: 13px;
 		letter-spacing: 0.05em;
-		transition: all 200ms ease;
+		transition:
+			background-color var(--dur-base) var(--ease-out),
+			border-color var(--dur-base) var(--ease-out),
+			color var(--dur-base) var(--ease-out),
+			transform var(--dur-press) var(--ease-press);
 		position: relative;
 		overflow: hidden;
 	}
 
-	.btn-secondary:hover {
-		background-color: rgba(var(--color-accent), 0.1);
-		border-color: rgba(var(--color-accent), 0.6);
+	@media (hover: hover) and (pointer: fine) {
+		.btn-secondary:hover {
+			background-color: rgba(var(--color-accent), 0.1);
+			border-color: rgba(var(--color-accent), 0.6);
+		}
 	}
 
-	/* Legacy neon button aliases — map to btn-primary */
+	.btn-secondary:active {
+		transform: scale(0.97);
+		transition-duration: 80ms;
+	}
+
+	/* Legacy neon button aliases — same treatment as btn-primary. */
 	.neon-button-magenta,
 	.neon-button-pink,
 	.neon-button-orange {
@@ -246,15 +322,29 @@
 		font-weight: 500;
 		font-size: 13px;
 		letter-spacing: 0.05em;
-		transition: all 200ms ease;
+		box-shadow: 0 1px 3px rgba(var(--color-accent), 0.12);
+		transition:
+			background-color var(--dur-base) var(--ease-out),
+			box-shadow var(--dur-base) var(--ease-out),
+			transform var(--dur-press) var(--ease-press),
+			opacity var(--dur-base) var(--ease-out);
 	}
 
-	.neon-button-magenta:hover,
-	.neon-button-pink:hover,
-	.neon-button-orange:hover {
-		opacity: 0.9;
-		box-shadow: 0 2px 8px rgba(var(--color-accent), 0.3);
-		transform: translateY(-1px);
+	@media (hover: hover) and (pointer: fine) {
+		.neon-button-magenta:hover,
+		.neon-button-pink:hover,
+		.neon-button-orange:hover {
+			opacity: 0.92;
+			box-shadow: 0 4px 14px -4px rgba(var(--color-accent), 0.4);
+			transform: translateY(-1px);
+		}
+	}
+
+	.neon-button-magenta:active,
+	.neon-button-pink:active,
+	.neon-button-orange:active {
+		transform: translateY(0) scale(0.97);
+		transition-duration: 80ms;
 	}
 
 	.neon-button-cyan,
@@ -269,29 +359,49 @@
 		font-weight: 400;
 		font-size: 13px;
 		letter-spacing: 0.05em;
-		transition: all 200ms ease;
+		transition:
+			background-color var(--dur-base) var(--ease-out),
+			border-color var(--dur-base) var(--ease-out),
+			color var(--dur-base) var(--ease-out),
+			transform var(--dur-press) var(--ease-press);
 	}
 
-	.neon-button-cyan:hover,
-	.neon-button-violet:hover,
-	.neon-button-emerald:hover {
-		background-color: rgba(var(--color-accent), 0.1);
-		border-color: rgba(var(--color-accent), 0.6);
+	@media (hover: hover) and (pointer: fine) {
+		.neon-button-cyan:hover,
+		.neon-button-violet:hover,
+		.neon-button-emerald:hover {
+			background-color: rgba(var(--color-accent), 0.1);
+			border-color: rgba(var(--color-accent), 0.6);
+		}
 	}
 
-	/* Card — terminal style */
+	.neon-button-cyan:active,
+	.neon-button-violet:active,
+	.neon-button-emerald:active {
+		transform: scale(0.97);
+		transition-duration: 80ms;
+	}
+
+	/* Card — terminal style. Hover lift trimmed to -1px and gated to
+	   real-pointer devices so touch screens don't fire phantom hovers. */
 	.dark-card {
 		border: 1px solid rgba(var(--color-border), 0.08);
 		border-radius: 0.5rem;
 		padding: 2rem;
 		background-color: rgb(var(--color-card-bg));
-		transition: all 200ms ease;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+		transition:
+			border-color var(--dur-base) var(--ease-out),
+			box-shadow var(--dur-base) var(--ease-out),
+			transform var(--dur-base) var(--ease-out);
 	}
 
-	.dark-card:hover {
-		border-color: rgba(var(--color-border), 0.2);
-		box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-		transform: translateY(-2px);
+	@media (hover: hover) and (pointer: fine) {
+		.dark-card:hover {
+			border-color: rgba(var(--color-border), 0.2);
+			box-shadow: 0 6px 16px -4px rgba(0, 0, 0, 0.18);
+			transform: translateY(-1px);
+		}
 	}
 
 	/* Check mark accent */
@@ -303,7 +413,7 @@
 	/* Links */
 	.neon-link {
 		color: rgb(var(--color-accent));
-		transition: color 200ms ease;
+		transition: color var(--dur-base) var(--ease-out);
 	}
 
 	.neon-link:hover {

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -176,9 +176,12 @@ export default function ContactForm({ subjects }: ContactFormProps) {
 						border border-[rgba(var(--color-cyan),0.4)]
 						shadow-[0_0_15px_rgba(var(--color-cyan),0.3)]
 						rounded-md text-center p-8
-						transition-all duration-500 ease-in-out
 						${isVisible ? "opacity-100 scale-100" : "opacity-0 scale-95"}
 					`}
+					style={{
+						transition:
+							"opacity var(--dur-slow) var(--ease-out), transform var(--dur-slow) var(--ease-out)",
+					}}
 				>
 					<h3 className="text-2xl font-semibold mb-3">
 						Thank You!
@@ -222,6 +225,10 @@ export default function ContactForm({ subjects }: ContactFormProps) {
 					onFocus={() => handleFieldFocus("name")}
 					required
 					disabled={status === "submitting"}
+					style={{
+						transition:
+							"border-color var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out)",
+					}}
 					className={`w-full p-3 bg-[rgba(var(--color-foreground),0.03)] border ${
 						fieldErrors.name
 							? "border-[rgba(var(--color-red),0.5)]"
@@ -251,6 +258,10 @@ export default function ContactForm({ subjects }: ContactFormProps) {
 					onFocus={() => handleFieldFocus("email")}
 					required
 					disabled={status === "submitting"}
+					style={{
+						transition:
+							"border-color var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out)",
+					}}
 					className={`w-full p-3 bg-[rgba(var(--color-foreground),0.03)] border ${
 						fieldErrors.email
 							? "border-[rgba(var(--color-red),0.5)]"
@@ -280,6 +291,10 @@ export default function ContactForm({ subjects }: ContactFormProps) {
 						onFocus={() => handleFieldFocus("subject")}
 						required
 						disabled={status === "submitting"}
+						style={{
+							transition:
+								"border-color var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out)",
+						}}
 						className={`w-full p-3 bg-[rgba(var(--color-foreground),0.03)] border ${
 							fieldErrors.subject
 								? "border-[rgba(var(--color-red),0.5)]"
@@ -302,6 +317,10 @@ export default function ContactForm({ subjects }: ContactFormProps) {
 						onFocus={() => handleFieldFocus("subject")}
 						required
 						disabled={status === "submitting"}
+						style={{
+							transition:
+								"border-color var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out)",
+						}}
 						className={`w-full p-3 bg-[rgba(var(--color-foreground),0.03)] border ${
 							fieldErrors.subject
 								? "border-[rgba(var(--color-red),0.5)]"
@@ -332,6 +351,10 @@ export default function ContactForm({ subjects }: ContactFormProps) {
 					required
 					disabled={status === "submitting"}
 					rows={6}
+					style={{
+						transition:
+							"border-color var(--dur-fast) var(--ease-out), box-shadow var(--dur-fast) var(--ease-out)",
+					}}
 					className={`w-full p-3 bg-[rgba(var(--color-foreground),0.03)] border ${
 						fieldErrors.message
 							? "border-[rgba(var(--color-red),0.5)]"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,11 +37,18 @@ export default function Header() {
 	}
 
 	useEffect(() => {
+		let ticking = false
 		const handleScroll = () => {
-			setScrolled(window.scrollY > 20)
+			if (ticking) return
+			requestAnimationFrame(() => {
+				const past = window.scrollY > 20
+				setScrolled((prev) => (prev !== past ? past : prev))
+				ticking = false
+			})
+			ticking = true
 		}
 
-		window.addEventListener("scroll", handleScroll)
+		window.addEventListener("scroll", handleScroll, { passive: true })
 		return () => window.removeEventListener("scroll", handleScroll)
 	}, [])
 
@@ -59,11 +66,15 @@ export default function Header() {
 
 	return (
 		<header
-			className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 border-b ${
+			className={`fixed top-0 left-0 right-0 z-50 border-b ${
 				scrolled
 					? "bg-[rgba(10,14,26,0.95)] backdrop-blur-[20px] border-[rgba(var(--color-border),0.1)]"
 					: "bg-transparent border-transparent"
 			}`}
+			style={{
+				transition:
+					"background-color var(--dur-base) var(--ease-out), border-color var(--dur-base) var(--ease-out), backdrop-filter var(--dur-base) var(--ease-out)",
+			}}
 		>
 			<div className="max-w-[1200px] mx-auto px-4 md:px-10 py-4 md:py-5 flex items-center justify-between">
 				{/* Left: glowing hexagon + doug.is */}
@@ -91,7 +102,10 @@ export default function Header() {
 							key={item.path}
 							href={item.path}
 							onClick={() => handleNavClick(item.path)}
-							className={`px-1.5 py-1 transition-colors duration-200 ${
+							style={{
+								transition: "color var(--dur-base) var(--ease-out)",
+							}}
+							className={`px-1.5 py-1 ${
 								isActive(pathname, item.path)
 									? "text-[rgb(var(--color-accent))]"
 									: "text-[rgba(var(--color-foreground),0.45)] hover:text-[rgb(var(--color-accent))]"
@@ -141,18 +155,28 @@ export default function Header() {
 					)}
 				</button>
 
-				{/* Mobile navigation overlay */}
+				{/* Mobile navigation overlay — iOS drawer curve.
+				   Items stagger in once the drawer has opened so the entry has tempo. */}
 				<div
-					className={`fixed inset-0 transform transition-transform duration-300 ease-in-out z-40 bg-[rgba(10,14,26,0.97)] backdrop-blur-[20px] ${
+					className={`fixed inset-0 transform z-40 bg-[rgba(10,14,26,0.97)] backdrop-blur-[20px] ${
 						isMenuOpen ? "translate-x-0" : "translate-x-full"
 					}`}
+					style={{
+						transition: "transform 320ms var(--ease-drawer)",
+					}}
 				>
 					<div className="flex flex-col items-center justify-center h-full gap-8">
-						{navItems.map((item) => (
+						{navItems.map((item, i) => (
 							<Link
 								key={item.path}
 								href={item.path}
-								className={`text-2xl tracking-[0.1em] transition-colors duration-200 ${
+								style={{
+									transition: "color var(--dur-base) var(--ease-out), opacity 280ms var(--ease-out), transform 280ms var(--ease-out)",
+									transitionDelay: isMenuOpen ? `${120 + i * 50}ms` : "0ms",
+									opacity: isMenuOpen ? 1 : 0,
+									transform: isMenuOpen ? "translateY(0)" : "translateY(8px)",
+								}}
+								className={`text-2xl tracking-[0.1em] ${
 									isActive(pathname, item.path)
 										? "text-[rgb(var(--color-accent))]"
 										: "text-[rgba(var(--color-foreground),0.6)]"
@@ -168,6 +192,11 @@ export default function Header() {
 						<Link
 							href="/connecting"
 							className="btn-primary mt-4"
+							style={{
+								transitionDelay: isMenuOpen ? `${120 + navItems.length * 50}ms` : "0ms",
+								opacity: isMenuOpen ? 1 : 0,
+								transform: isMenuOpen ? "translateY(0)" : "translateY(8px)",
+							}}
 							onClick={() => setIsMenuOpen(false)}
 						>
 							Get in Touch

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import Link from "next/link"
+import TerminalText from "@/components/TerminalText"
+
+const HEXES = [
+	{ size: 120, x: "80%", y: "15%", delay: "0s", parallaxFactor: 0.05 },
+	{ size: 80, x: "10%", y: "70%", delay: "1s", parallaxFactor: 0.1 },
+	{ size: 60, x: "70%", y: "80%", delay: "2s", parallaxFactor: 0.15 },
+	{ size: 40, x: "20%", y: "20%", delay: "0.5s", parallaxFactor: 0.2 },
+]
+
+export default function HeroSection() {
+	const parallaxRefs = useRef<(HTMLDivElement | null)[]>([])
+
+	useEffect(() => {
+		// Direct DOM writes via rAF — no React state, no reconciliation.
+		// Parallax lives on wrapper divs so the SVGs inside stay free to
+		// run their hex-float keyframe.
+		let ticking = false
+		const onScroll = () => {
+			if (ticking) return
+			requestAnimationFrame(() => {
+				const y = window.scrollY
+				parallaxRefs.current.forEach((el, i) => {
+					if (!el) return
+					const factor = HEXES[i]?.parallaxFactor ?? 0
+					el.style.transform = `translate3d(0, ${-y * factor}px, 0)`
+				})
+				ticking = false
+			})
+			ticking = true
+		}
+
+		// Honor reduced-motion: skip parallax entirely.
+		const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+		if (reduced) return
+
+		window.addEventListener("scroll", onScroll, { passive: true })
+		return () => window.removeEventListener("scroll", onScroll)
+	}, [])
+
+	return (
+		<section className="flex items-center px-5 md:px-10 pt-[220px] pb-[200px] relative">
+			{/* Floating hexagons — parallax on wrapper, keyframe float on SVG */}
+			<div className="absolute inset-0 overflow-hidden pointer-events-none">
+				{HEXES.map((hex, i) => (
+					<div
+						key={i}
+						ref={(el) => {
+							parallaxRefs.current[i] = el
+						}}
+						className="absolute will-change-transform"
+						style={{
+							left: hex.x,
+							top: hex.y,
+						}}
+					>
+						<svg
+							className="opacity-[0.06]"
+							style={{
+								width: `${hex.size}px`,
+								height: `${hex.size * 1.155}px`,
+								animation: `hex-float 8s ease-in-out ${hex.delay} infinite`,
+							}}
+							viewBox="0 0 86.6 100"
+						>
+							<polygon
+								points="43.3,0 86.6,25 86.6,75 43.3,100 0,75 0,25"
+								fill="none"
+								className="stroke-[rgb(var(--color-accent))]"
+								strokeWidth="1"
+							/>
+						</svg>
+					</div>
+				))}
+			</div>
+
+			<div className="max-w-[1200px] mx-auto w-full grid grid-cols-1 md:grid-cols-2 gap-10 md:gap-20 items-center">
+				{/* Left — terminal */}
+				<div
+					className="bg-[rgb(var(--color-background-alt))] rounded-xl border border-[rgba(var(--color-border),0.12)] overflow-hidden hero-stagger"
+					style={{ animationDelay: "0ms" }}
+				>
+					{/* Terminal title bar */}
+					<div className="px-4 py-3 border-b border-[rgba(var(--color-border),0.08)] flex items-center gap-2">
+						<div className="w-2.5 h-2.5 rounded-full bg-[#ff5f57]" />
+						<div className="w-2.5 h-2.5 rounded-full bg-[#febc2e]" />
+						<div className="w-2.5 h-2.5 rounded-full bg-[#28c840]" />
+						<span className="text-[11px] text-[rgba(var(--color-foreground),0.45)] ml-3 font-[family-name:var(--font-mono)]">
+							~/doug-rogers
+						</span>
+					</div>
+					{/* Terminal content */}
+					<div className="p-6 min-h-[420px]">
+						<TerminalText />
+					</div>
+				</div>
+
+				{/* Right — headline. Each child staggers in 60ms apart. */}
+				<div>
+					{/* Circular B&W photo */}
+					<div
+						className="w-[120px] h-[120px] rounded-full overflow-hidden border-2 border-[rgb(var(--color-accent))] mb-7 hero-stagger"
+						style={{ animationDelay: "60ms" }}
+					>
+						{/* eslint-disable-next-line @next/next/no-img-element */}
+						<img
+							src="/images/doug-2024-cropped-compr.png"
+							alt="Doug Rogers"
+							className="w-full h-full object-cover grayscale brightness-110 contrast-105"
+						/>
+					</div>
+					<h1
+						className="font-[family-name:var(--font-display)] text-[clamp(40px,5vw,64px)] font-bold leading-[1.1] mb-6 hero-stagger"
+						style={{ animationDelay: "120ms" }}
+					>
+						Ideas to products.{" "}
+						<span className="text-[rgb(var(--color-accent))]">
+							Zero to one.
+						</span>
+					</h1>
+					<p
+						className="text-base leading-[1.7] text-[rgba(var(--color-foreground),0.45)] max-w-[440px] mb-10 hero-stagger"
+						style={{ animationDelay: "180ms" }}
+					>
+						I&apos;m not a theoretical advisor. I&apos;ve raised capital,
+						invested capital, pivoted, shipped, sold. I excel at taking a raw
+						idea and turning it into something customers actually pay for,
+						validating all the way.
+					</p>
+					<div
+						className="flex flex-wrap gap-4 hero-stagger"
+						style={{ animationDelay: "240ms" }}
+					>
+						<Link href="/connecting" className="btn-primary">
+							Get in Touch
+						</Link>
+						<Link href="/thinking" className="btn-secondary">
+							Read My Writing
+						</Link>
+					</div>
+				</div>
+			</div>
+		</section>
+	)
+}

--- a/src/components/TerminalText.tsx
+++ b/src/components/TerminalText.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useRef } from "react"
 
 const allLines = [
 	"$ whoami",
-	"doug rogers \u2014 engineer, founder, advisor",
+	"doug rogers — engineer, founder, advisor",
 	"",
 	"$ cat experience.log",
 	"25+ years building products",
@@ -15,118 +15,151 @@ const allLines = [
 	"$ cat strengths.txt",
 	"rapid prototyping & MVPs",
 	"idea validation & ICP identification",
-	"0 \u2192 1 product development",
+	"0 → 1 product development",
 	"customer empathy (the real kind)",
 	"",
 	"$ echo $STATUS",
 	"still shipping.",
 ]
 
+const COMMAND_SPEED = 45
+const TEXT_SPEED = 18
+const PROMPT = "❯ " // ❯
+
+function makeLineEl(line: string): HTMLDivElement {
+	const div = document.createElement("div")
+	div.style.minHeight = "25px"
+
+	if (line.startsWith("$")) {
+		const promptSpan = document.createElement("span")
+		promptSpan.style.color = "rgb(var(--color-accent))"
+		promptSpan.textContent = PROMPT
+		const textSpan = document.createElement("span")
+		textSpan.style.color = "rgb(var(--color-foreground))"
+		textSpan.textContent = line.substring(2)
+		div.appendChild(promptSpan)
+		div.appendChild(textSpan)
+	} else {
+		const span = document.createElement("span")
+		span.style.color = "rgba(var(--color-foreground), 0.55)"
+		span.textContent = line
+		div.appendChild(span)
+	}
+	return div
+}
+
 export default function TerminalText() {
-	const [lines, setLines] = useState<string[]>([])
-	const [currentLine, setCurrentLine] = useState(0)
-	const [currentChar, setCurrentChar] = useState(0)
-	const [showCursor, setShowCursor] = useState(true)
+	const containerRef = useRef<HTMLDivElement>(null)
+	const cancelledRef = useRef(false)
 
 	useEffect(() => {
-		const timer = setInterval(() => {
-			setShowCursor((prev) => !prev)
-		}, 530)
-		return () => clearInterval(timer)
+		const container = containerRef.current
+		if (!container) return
+
+		cancelledRef.current = false
+
+		// Reduced-motion: dump everything immediately, no typing.
+		const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+		if (reduced) {
+			allLines.forEach((line) => {
+				container.appendChild(makeLineEl(line || " "))
+			})
+			return () => {
+				cancelledRef.current = true
+				container.replaceChildren()
+			}
+		}
+
+		// Cursor element — animation is CSS-only; we just move it between
+		// lines and remove it when done.
+		const cursor = document.createElement("span")
+		cursor.textContent = "█"
+		cursor.style.color = "rgb(var(--color-accent))"
+		cursor.style.marginLeft = "1px"
+		cursor.style.animation = "terminal-blink 1s steps(2) infinite"
+
+		const typeLine = (lineIndex: number, charIndex: number) => {
+			if (cancelledRef.current) return
+			if (lineIndex >= allLines.length) {
+				cursor.remove()
+				return
+			}
+
+			const line = allLines[lineIndex]
+
+			// Empty line — just append a blank and move on after a short pause.
+			if (line === "") {
+				const blank = document.createElement("div")
+				blank.style.minHeight = "25px"
+				container.insertBefore(blank, cursor)
+				setTimeout(() => typeLine(lineIndex + 1, 0), 200)
+				return
+			}
+
+			// First char of a line — make a fresh row and put the cursor in it.
+			if (charIndex === 0) {
+				const row = document.createElement("div")
+				row.style.minHeight = "25px"
+
+				if (line.startsWith("$")) {
+					const promptSpan = document.createElement("span")
+					promptSpan.style.color = "rgb(var(--color-accent))"
+					promptSpan.textContent = PROMPT
+					row.appendChild(promptSpan)
+					const textSpan = document.createElement("span")
+					textSpan.style.color = "rgb(var(--color-foreground))"
+					textSpan.dataset.terminalContent = "true"
+					row.appendChild(textSpan)
+				} else {
+					const textSpan = document.createElement("span")
+					textSpan.style.color = "rgba(var(--color-foreground), 0.55)"
+					textSpan.dataset.terminalContent = "true"
+					row.appendChild(textSpan)
+				}
+
+				row.appendChild(cursor)
+				container.appendChild(row)
+			}
+
+			const isCommand = line.startsWith("$")
+			const visible = isCommand ? line.substring(2) : line
+			const target = visible.substring(0, charIndex + 1)
+
+			// Update only the text span — no React, no full re-render.
+			const lastRow = container.lastElementChild as HTMLElement | null
+			const textSpan = lastRow?.querySelector(
+				'[data-terminal-content="true"]'
+			) as HTMLElement | null
+			if (textSpan) textSpan.textContent = target
+
+			const charsToType = visible.length
+
+			if (charIndex + 1 < charsToType) {
+				setTimeout(
+					() => typeLine(lineIndex, charIndex + 1),
+					isCommand ? COMMAND_SPEED : TEXT_SPEED
+				)
+			} else {
+				setTimeout(() => typeLine(lineIndex + 1, 0), 50)
+			}
+		}
+
+		typeLine(0, 0)
+
+		return () => {
+			cancelledRef.current = true
+			container.replaceChildren()
+		}
 	}, [])
-
-	useEffect(() => {
-		if (currentLine >= allLines.length) return
-
-		const line = allLines[currentLine]
-		if (line === "") {
-			setTimeout(() => {
-				setLines((prev) => [...prev, ""])
-				setCurrentLine((prev) => prev + 1)
-				setCurrentChar(0)
-			}, 200)
-			return
-		}
-
-		if (currentChar >= line.length) {
-			setLines((prev) => [...prev, line])
-			setCurrentLine((prev) => prev + 1)
-			setCurrentChar(0)
-			return
-		}
-
-		const isCommand = line.startsWith("$")
-		const speed = isCommand ? 45 : 18
-
-		const timer = setTimeout(() => {
-			setCurrentChar((prev) => prev + 1)
-		}, speed)
-
-		return () => clearTimeout(timer)
-	}, [currentLine, currentChar])
-
-	const typingLine =
-		currentLine < allLines.length
-			? allLines[currentLine].substring(0, currentChar)
-			: ""
 
 	return (
 		<div
+			ref={containerRef}
 			style={{
 				fontFamily: "var(--font-body, 'JetBrains Mono', monospace)",
 				fontSize: "14px",
 				lineHeight: "1.8",
 			}}
-		>
-			{lines.map((line, i) => (
-				<div key={i} style={{ minHeight: "25px" }}>
-					{line.startsWith("$") ? (
-						<span>
-							<span style={{ color: "rgb(var(--color-accent))" }}>
-								&#10095;{" "}
-							</span>
-							<span style={{ color: "rgb(var(--color-foreground))" }}>
-								{line.substring(2)}
-							</span>
-						</span>
-					) : (
-						<span
-							style={{ color: "rgba(var(--color-foreground), 0.55)" }}
-						>
-							{line}
-						</span>
-					)}
-				</div>
-			))}
-			{currentLine < allLines.length && (
-				<div style={{ minHeight: "25px" }}>
-					{typingLine.startsWith("$") ? (
-						<span>
-							<span style={{ color: "rgb(var(--color-accent))" }}>
-								&#10095;{" "}
-							</span>
-							<span style={{ color: "rgb(var(--color-foreground))" }}>
-								{typingLine.substring(2)}
-							</span>
-						</span>
-					) : (
-						<span
-							style={{ color: "rgba(var(--color-foreground), 0.55)" }}
-						>
-							{typingLine}
-						</span>
-					)}
-					<span
-						style={{
-							opacity: showCursor ? 1 : 0,
-							color: "rgb(var(--color-accent))",
-							transition: "opacity 0.1s",
-						}}
-					>
-						&#9610;
-					</span>
-				</div>
-			)}
-		</div>
+		/>
 	)
 }

--- a/src/components/TerminalText.tsx
+++ b/src/components/TerminalText.tsx
@@ -87,11 +87,13 @@ export default function TerminalText() {
 
 			const line = allLines[lineIndex]
 
-			// Empty line — just append a blank and move on after a short pause.
+			// Empty line — append a blank and pause briefly. The cursor lives
+			// inside the previous row, so we append the blank after it (not via
+			// insertBefore, which would require cursor to be a direct child).
 			if (line === "") {
 				const blank = document.createElement("div")
 				blank.style.minHeight = "25px"
-				container.insertBefore(blank, cursor)
+				container.appendChild(blank)
 				setTimeout(() => typeLine(lineIndex + 1, 0), 200)
 				return
 			}

--- a/src/components/admin/AdminNavigation.tsx
+++ b/src/components/admin/AdminNavigation.tsx
@@ -69,7 +69,8 @@ export default function AdminNavigation() {
 			<aside
 				className={`${
 					isOpen ? "translate-x-0" : "-translate-x-full"
-				} fixed inset-y-0 left-0 z-40 w-64 transition-transform duration-300 ease-in-out md:translate-x-0 admin-navigation`}
+				} fixed inset-y-0 left-0 z-40 w-64 md:translate-x-0 admin-navigation`}
+				style={{ transition: "transform 280ms var(--ease-drawer)" }}
 			>
 				{/* Admin Logo/Title */}
 				<div className="admin-header">

--- a/src/components/mvp/MVPLandingPage.tsx
+++ b/src/components/mvp/MVPLandingPage.tsx
@@ -5,6 +5,38 @@ import Image from "next/image"
 import { MVPVariantConfig } from "@/lib/mvp-variants/types"
 import { useAnalytics } from "@/lib/analytics/context"
 
+// Reveal-on-scroll: flips data-revealed once the element crosses the viewport.
+// Children stagger via CSS `transition-delay` set with the `data-stagger` index.
+function useReveal<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null)
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    // Already in view (e.g. on a short page) → reveal immediately, skip the observer.
+    const rect = el.getBoundingClientRect()
+    if (rect.top < window.innerHeight) {
+      el.setAttribute("data-revealed", "true")
+      return
+    }
+
+    const obs = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.setAttribute("data-revealed", "true")
+            obs.unobserve(entry.target)
+          }
+        })
+      },
+      { rootMargin: "0px 0px -10% 0px", threshold: 0.05 }
+    )
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [])
+  return ref
+}
+
 interface MVPLandingPageProps {
   variant: MVPVariantConfig
 }
@@ -96,6 +128,15 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
   const formRef = useRef<HTMLDivElement>(null)
   const calLoadedRef = useRef(false)
   const analytics = useAnalytics()
+
+  // Reveal-on-scroll wrappers — one per section that has a grid we want to stagger.
+  const statsRevealRef = useReveal<HTMLDivElement>()
+  const featuresRevealRef = useReveal<HTMLDivElement>()
+  const audienceRevealRef = useReveal<HTMLDivElement>()
+  const credentialsRevealRef = useReveal<HTMLDivElement>()
+  const processRevealRef = useReveal<HTMLDivElement>()
+  const faqRevealRef = useReveal<HTMLDivElement>()
+  const formRevealRef = useReveal<HTMLDivElement>()
 
   // Track page view with UTM params on mount
   useEffect(() => {
@@ -276,19 +317,95 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
       <style>{`
         .mvp-landing * { box-sizing: border-box; }
         .mvp-landing h1, .mvp-landing h2, .mvp-landing h3, .mvp-landing h4 { font-family: 'Inter', system-ui, sans-serif; }
-        @keyframes mvp-float { 0%, 100% { transform: translateY(0px); } 50% { transform: translateY(-12px); } }
-        @keyframes mvp-glow-pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 0.8; } }
+
+        /* Background atmosphere — tightened range so it reads as ambient, not twitchy. */
+        @keyframes mvp-glow-pulse { 0%, 100% { opacity: 0.5; } 50% { opacity: 0.7; } }
+
+        /* Hero entrance — 12px lift, 480ms with the system ease-out. */
+        @keyframes mvp-hero-in { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+        .mvp-hero-in { animation: mvp-hero-in var(--dur-hero) var(--ease-out) both; }
+
+        /* Brand gradient on the headline — subtle drift, slowed enough to feel ambient. */
         @keyframes mvp-gradient-shift { 0% { background-position: 0% 50%; } 50% { background-position: 100% 50%; } 100% { background-position: 0% 50%; } }
-        @keyframes mvp-slide-up { from { opacity: 0; transform: translateY(30px); } to { opacity: 1; transform: translateY(0); } }
-        .mvp-gradient-text { background: linear-gradient(135deg, #60A5FA, #A78BFA, #34D399); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; background-size: 200% 200%; animation: mvp-gradient-shift 6s ease infinite; }
-        .mvp-card-glow:hover { box-shadow: 0 0 40px rgba(59, 130, 246, 0.08), 0 8px 32px rgba(0, 0, 0, 0.3); }
-        .mvp-stat-card { background: linear-gradient(135deg, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 0.8)); backdrop-filter: blur(12px); }
-        .mvp-feature-icon { background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(167, 139, 250, 0.15)); }
-        .mvp-step-number { background: linear-gradient(135deg, #3B82F6, #8B5CF6); }
-        .mvp-cta-btn { background: linear-gradient(135deg, #3B82F6, #6366F1); transition: all 0.3s ease; }
-        .mvp-cta-btn:hover { background: linear-gradient(135deg, #2563EB, #4F46E5); box-shadow: 0 0 40px rgba(59, 130, 246, 0.35); transform: translateY(-2px); }
-        .mvp-form-input { transition: all 0.2s ease; }
+        .mvp-gradient-text {
+          background: linear-gradient(135deg, #60A5FA, #A78BFA, #34D399);
+          -webkit-background-clip: text;
+          -webkit-text-fill-color: transparent;
+          background-clip: text;
+          background-size: 200% 200%;
+          animation: mvp-gradient-shift 14s ease-in-out infinite;
+        }
+
+        /* Trust-badge dot — gentle warm pulse instead of the default animate-pulse wobble. */
+        @keyframes mvp-dot-pulse { 0%, 100% { transform: scale(1); opacity: 0.85; } 50% { transform: scale(1.15); opacity: 1; } }
+        .mvp-dot-pulse { animation: mvp-dot-pulse 2.4s var(--ease-in-out) infinite; }
+
+        /* Scroll reveal — wrapper sets data-revealed="true" when in view.
+           Children with .mvp-reveal-child stagger their entry via transition-delay. */
+        .mvp-reveal { opacity: 0; transform: translateY(16px); transition: opacity var(--dur-slow) var(--ease-out), transform var(--dur-slow) var(--ease-out); }
+        .mvp-reveal[data-revealed="true"] { opacity: 1; transform: translateY(0); }
+
+        .mvp-reveal-children > .mvp-reveal-child { opacity: 0; transform: translateY(16px); transition: opacity var(--dur-slow) var(--ease-out), transform var(--dur-slow) var(--ease-out); }
+        .mvp-reveal-children[data-revealed="true"] > .mvp-reveal-child { opacity: 1; transform: translateY(0); }
+
+        /* Stat / feature / audience cards. Hover lift gated to real pointers. */
+        .mvp-stat-card { background: linear-gradient(135deg, rgba(30, 41, 59, 0.8), rgba(15, 23, 42, 0.8)); backdrop-filter: blur(12px); transition: border-color var(--dur-base) var(--ease-out), box-shadow var(--dur-base) var(--ease-out), transform var(--dur-base) var(--ease-out); }
+        .mvp-feature-icon { background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(167, 139, 250, 0.15)); transition: transform var(--dur-base) var(--ease-out); }
+        .mvp-step-number { background: linear-gradient(135deg, #3B82F6, #8B5CF6); box-shadow: 0 0 24px rgba(59, 130, 246, 0.18); transition: box-shadow var(--dur-slow) var(--ease-out); }
+
+        @media (hover: hover) and (pointer: fine) {
+          .mvp-card-glow:hover { box-shadow: 0 0 40px rgba(59, 130, 246, 0.08), 0 8px 32px rgba(0, 0, 0, 0.3); }
+          .mvp-feature-card:hover .mvp-feature-icon { transform: scale(1.06); }
+          .mvp-step-card:hover .mvp-step-number { box-shadow: 0 0 36px rgba(99, 102, 241, 0.32); }
+        }
+
+        /* Primary CTA — proper transitions + press feedback. */
+        .mvp-cta-btn {
+          background: linear-gradient(135deg, #3B82F6, #6366F1);
+          box-shadow: 0 4px 14px -4px rgba(59, 130, 246, 0.32);
+          transition:
+            background var(--dur-base) var(--ease-out),
+            box-shadow var(--dur-base) var(--ease-out),
+            transform var(--dur-press) var(--ease-press);
+        }
+        @media (hover: hover) and (pointer: fine) {
+          .mvp-cta-btn:hover {
+            background: linear-gradient(135deg, #2563EB, #4F46E5);
+            box-shadow: 0 8px 28px -8px rgba(59, 130, 246, 0.5);
+            transform: translateY(-1px);
+          }
+        }
+        .mvp-cta-btn:active { transform: translateY(0) scale(0.97); transition-duration: 80ms; }
+        .mvp-cta-btn:disabled { transform: none !important; }
+
+        /* Submit-state crossfade — text and spinner stack in the same slot,
+           opacity + blur bridge the swap so neither side pops. */
+        .mvp-cta-content { position: relative; display: inline-flex; align-items: center; justify-content: center; gap: 0.75rem; }
+        .mvp-cta-layer { transition: opacity var(--dur-fast) var(--ease-out), filter var(--dur-fast) var(--ease-out); }
+        .mvp-cta-layer[data-hidden="true"] { opacity: 0; filter: blur(2px); pointer-events: none; }
+        .mvp-cta-layer[data-stacked="true"] { position: absolute; inset: 0; }
+
+        /* Form inputs — specific properties, no surprise re-paints. */
+        .mvp-form-input {
+          transition:
+            border-color var(--dur-fast) var(--ease-out),
+            box-shadow var(--dur-fast) var(--ease-out),
+            background-color var(--dur-fast) var(--ease-out);
+        }
         .mvp-form-input:focus { box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2); }
+
+        /* FAQ accordion — grid-template-rows trick for true auto-height. */
+        .mvp-faq-grid { display: grid; grid-template-rows: 0fr; transition: grid-template-rows var(--dur-slow) var(--ease-out); }
+        .mvp-faq-grid[data-open="true"] { grid-template-rows: 1fr; }
+        .mvp-faq-grid > * { overflow: hidden; min-height: 0; }
+        .mvp-faq-chevron { transition: transform var(--dur-base) var(--ease-out), background-color var(--dur-base) var(--ease-out); }
+        .mvp-faq-chevron[data-open="true"] { transform: rotate(180deg); background-color: rgba(59, 130, 246, 0.2); }
+
+        /* Success state — scale-from-0.95 (never scale-from-0) entrance. */
+        @keyframes mvp-success-in { from { opacity: 0; transform: scale(0.95); } to { opacity: 1; transform: scale(1); } }
+        .mvp-success-in { animation: mvp-success-in var(--dur-slow) var(--ease-out) both; }
+        @keyframes mvp-check-pop { from { opacity: 0; transform: scale(0.6); } 60% { opacity: 1; transform: scale(1.08); } to { opacity: 1; transform: scale(1); } }
+        .mvp-check-pop { animation: mvp-check-pop 420ms var(--ease-out) 80ms both; }
       `}</style>
 
       <div className="mvp-landing bg-[#0B1120] text-[#F8FAFC]">
@@ -304,10 +421,10 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
             <div className="absolute inset-0 opacity-[0.03]" style={{ backgroundImage: "linear-gradient(rgba(255,255,255,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.1) 1px, transparent 1px)", backgroundSize: "60px 60px" }} />
           </div>
 
-          <div className="relative max-w-5xl mx-auto px-6 py-20 md:py-0 text-center" style={{ animation: "mvp-slide-up 0.8s ease-out" }}>
+          <div className="relative max-w-5xl mx-auto px-6 py-20 md:py-0 text-center mvp-hero-in">
             {/* Trust badge */}
             <div className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-[rgba(59,130,246,0.08)] border border-[rgba(59,130,246,0.2)] text-sm text-blue-400 mb-10 backdrop-blur-sm">
-              <span className="w-2 h-2 rounded-full bg-emerald-400 animate-pulse" />
+              <span className="w-2 h-2 rounded-full bg-emerald-400 mvp-dot-pulse" />
               Now accepting projects
             </div>
 
@@ -374,11 +491,12 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
             <p className="text-[#94A3B8] text-lg md:text-xl text-center max-w-3xl mx-auto mb-16 leading-relaxed">
               {variant.valueProp.description}
             </p>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div ref={statsRevealRef} className="mvp-reveal-children grid grid-cols-1 md:grid-cols-3 gap-6">
               {variant.valueProp.stats.map((stat, idx) => (
                 <div
                   key={stat.label}
-                  className="mvp-stat-card text-center p-10 rounded-3xl border border-[rgba(148,163,184,0.08)] hover:border-[rgba(59,130,246,0.2)] transition-all duration-300"
+                  className="mvp-reveal-child mvp-stat-card text-center p-10 rounded-3xl border border-[rgba(148,163,184,0.08)] hover:border-[rgba(59,130,246,0.2)]"
+                  style={{ transitionDelay: `${idx * 60}ms` }}
                 >
                   <div className={`text-5xl md:text-6xl font-extrabold mb-3 ${idx === 0 ? "text-blue-400" : idx === 1 ? "text-emerald-400" : "text-purple-400"}`}>
                     {stat.value}
@@ -404,16 +522,28 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
             <p className="text-[#94A3B8] text-lg md:text-xl text-center max-w-2xl mx-auto mb-16">
               {variant.features.description}
             </p>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              {variant.features.items.map((item) => (
+            <div ref={featuresRevealRef} className="mvp-reveal-children grid grid-cols-1 md:grid-cols-2 gap-6">
+              {variant.features.items.map((item, idx) => (
                 <div
                   key={item.title}
-                  className="mvp-card-glow group p-8 rounded-3xl bg-[#111827] border border-[rgba(148,163,184,0.08)] hover:border-[rgba(99,102,241,0.3)] transition-all duration-300"
+                  className="mvp-reveal-child mvp-card-glow mvp-feature-card group p-8 rounded-3xl bg-[#111827] border border-[rgba(148,163,184,0.08)] hover:border-[rgba(99,102,241,0.3)]"
+                  style={{
+                    transitionDelay: `${idx * 60}ms`,
+                    transitionProperty:
+                      "opacity, transform, border-color, box-shadow",
+                    transitionDuration: "var(--dur-slow)",
+                    transitionTimingFunction: "var(--ease-out)",
+                  }}
                 >
-                  <div className="mvp-feature-icon w-14 h-14 rounded-2xl flex items-center justify-center text-blue-400 mb-5 group-hover:scale-110 transition-transform duration-300">
+                  <div className="mvp-feature-icon w-14 h-14 rounded-2xl flex items-center justify-center text-blue-400 mb-5">
                     {iconMap[item.icon] || iconMap.rocket}
                   </div>
-                  <h3 className="text-xl font-bold mb-3 group-hover:text-blue-300 transition-colors">{item.title}</h3>
+                  <h3
+                    className="text-xl font-bold mb-3 group-hover:text-blue-300"
+                    style={{ transition: "color var(--dur-base) var(--ease-out)" }}
+                  >
+                    {item.title}
+                  </h3>
                   <p className="text-[#94A3B8] leading-relaxed">{item.description}</p>
                 </div>
               ))}
@@ -432,11 +562,17 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
             <p className="text-[#94A3B8] text-lg md:text-xl text-center max-w-2xl mx-auto mb-12">
               {variant.audience.description}
             </p>
-            <div className="space-y-4">
-              {variant.audience.items.map((item) => (
+            <div ref={audienceRevealRef} className="mvp-reveal-children space-y-4">
+              {variant.audience.items.map((item, idx) => (
                 <div
                   key={item}
-                  className="flex items-start gap-4 p-5 rounded-2xl bg-[#111827] border border-[rgba(148,163,184,0.08)] hover:border-[rgba(59,130,246,0.2)] transition-all duration-300"
+                  className="mvp-reveal-child flex items-start gap-4 p-5 rounded-2xl bg-[#111827] border border-[rgba(148,163,184,0.08)] hover:border-[rgba(59,130,246,0.2)]"
+                  style={{
+                    transitionDelay: `${idx * 50}ms`,
+                    transitionProperty: "opacity, transform, border-color",
+                    transitionDuration: "var(--dur-slow)",
+                    transitionTimingFunction: "var(--ease-out)",
+                  }}
                 >
                   <div className="mt-0.5 w-6 h-6 rounded-full bg-blue-500/15 flex items-center justify-center flex-shrink-0">
                     <svg className="w-3.5 h-3.5 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
@@ -457,7 +593,7 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
           <div className="absolute left-[10%] top-1/2 -translate-y-1/2 w-[300px] h-[300px] bg-blue-600/10 rounded-full blur-[80px]" />
 
           <div className="relative max-w-5xl mx-auto px-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-12 md:gap-20 items-center">
+            <div ref={credentialsRevealRef} className="mvp-reveal grid grid-cols-1 md:grid-cols-2 gap-12 md:gap-20 items-center">
               {/* Photo side */}
               <div className="text-center md:text-left">
                 <div className="relative inline-block mb-10">
@@ -516,13 +652,17 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
             <h2 className="text-3xl md:text-5xl font-bold text-center mb-20">
               {variant.process.headline}
             </h2>
-            <div className="grid grid-cols-1 md:grid-cols-4 gap-8 relative">
+            <div ref={processRevealRef} className="mvp-reveal-children grid grid-cols-1 md:grid-cols-4 gap-8 relative">
               {/* Connecting line (desktop) */}
               <div className="hidden md:block absolute top-12 left-[12.5%] right-[12.5%] h-px bg-gradient-to-r from-blue-500/0 via-blue-500/40 to-blue-500/0" />
 
-              {variant.process.steps.map((step) => (
-                <div key={step.number} className="relative text-center group">
-                  <div className="mvp-step-number relative z-10 w-24 h-24 rounded-3xl flex items-center justify-center text-3xl font-extrabold text-white mx-auto mb-8 shadow-[0_0_30px_rgba(59,130,246,0.2)] group-hover:shadow-[0_0_40px_rgba(99,102,241,0.3)] transition-shadow duration-300">
+              {variant.process.steps.map((step, idx) => (
+                <div
+                  key={step.number}
+                  className="mvp-reveal-child mvp-step-card relative text-center group"
+                  style={{ transitionDelay: `${idx * 70}ms` }}
+                >
+                  <div className="mvp-step-number relative z-10 w-24 h-24 rounded-3xl flex items-center justify-center text-3xl font-extrabold text-white mx-auto mb-8">
                     {step.number}
                   </div>
                   <h3 className="font-bold text-lg mb-3">{step.title}</h3>
@@ -543,39 +683,51 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
             <h2 className="text-3xl md:text-5xl font-bold text-center mb-16">
               {variant.faq.headline}
             </h2>
-            <div className="space-y-4">
-              {variant.faq.items.map((item, idx) => (
-                <div
-                  key={item.question}
-                  className="rounded-2xl border border-[rgba(148,163,184,0.08)] overflow-hidden transition-all duration-200 hover:border-[rgba(148,163,184,0.15)]"
-                >
-                  <button
-                    onClick={() => setOpenFaqIndex(openFaqIndex === idx ? null : idx)}
-                    className="w-full flex items-center justify-between p-6 md:p-7 text-left bg-[#111827] hover:bg-[#1E293B]/60 transition-colors"
-                  >
-                    <span className="font-semibold text-lg pr-4">{item.question}</span>
-                    <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 transition-all duration-200 ${openFaqIndex === idx ? "bg-blue-500/20 rotate-180" : "bg-[rgba(148,163,184,0.08)]"}`}>
-                      <svg
-                        className="w-4 h-4 text-blue-400"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={2.5}
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                      </svg>
-                    </div>
-                  </button>
+            <div ref={faqRevealRef} className="mvp-reveal-children space-y-4">
+              {variant.faq.items.map((item, idx) => {
+                const open = openFaqIndex === idx
+                return (
                   <div
-                    className="overflow-hidden transition-all duration-300"
-                    style={{ maxHeight: openFaqIndex === idx ? "500px" : "0px", opacity: openFaqIndex === idx ? 1 : 0 }}
+                    key={item.question}
+                    className="mvp-reveal-child rounded-2xl border border-[rgba(148,163,184,0.08)] overflow-hidden hover:border-[rgba(148,163,184,0.15)]"
+                    style={{
+                      transitionDelay: `${idx * 40}ms`,
+                      transitionProperty: "opacity, transform, border-color",
+                      transitionDuration: "var(--dur-slow)",
+                      transitionTimingFunction: "var(--ease-out)",
+                    }}
                   >
-                    <div className="px-6 md:px-7 pb-6 md:pb-7 bg-[#111827] text-[#94A3B8] leading-relaxed">
-                      {item.answer}
+                    <button
+                      onClick={() => setOpenFaqIndex(open ? null : idx)}
+                      className="w-full flex items-center justify-between p-6 md:p-7 text-left bg-[#111827] hover:bg-[#1E293B]/60"
+                      style={{ transition: "background-color var(--dur-base) var(--ease-out)" }}
+                    >
+                      <span className="font-semibold text-lg pr-4">{item.question}</span>
+                      <div
+                        className="mvp-faq-chevron w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 bg-[rgba(148,163,184,0.08)]"
+                        data-open={open ? "true" : "false"}
+                      >
+                        <svg
+                          className="w-4 h-4 text-blue-400"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2.5}
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                        </svg>
+                      </div>
+                    </button>
+                    <div className="mvp-faq-grid" data-open={open ? "true" : "false"}>
+                      <div>
+                        <div className="px-6 md:px-7 pb-6 md:pb-7 bg-[#111827] text-[#94A3B8] leading-relaxed">
+                          {item.answer}
+                        </div>
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           </div>
         </section>
@@ -594,8 +746,8 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
             </p>
 
             {formStatus === "success" ? (
-              <div className="text-center">
-                <div className="w-20 h-20 rounded-full bg-emerald-500/15 flex items-center justify-center mx-auto mb-6 border border-emerald-500/25">
+              <div className="text-center mvp-success-in">
+                <div className="mvp-check-pop w-20 h-20 rounded-full bg-emerald-500/15 flex items-center justify-center mx-auto mb-6 border border-emerald-500/25">
                   <svg className="w-10 h-10 text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                   </svg>
@@ -612,10 +764,13 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
                 />
               </div>
             ) : (
-              <div className="p-8 md:p-10 rounded-3xl bg-[#111827] border border-[rgba(148,163,184,0.08)]">
+              <div ref={formRevealRef} className="mvp-reveal p-8 md:p-10 rounded-3xl bg-[#111827] border border-[rgba(148,163,184,0.08)]">
                 <form onSubmit={handleSubmit} className="space-y-5">
                   {formStatus === "error" && (
-                    <div className="p-4 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
+                    <div
+                      className="p-4 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm"
+                      style={{ animation: "mvp-success-in var(--dur-slow) var(--ease-out) both" }}
+                    >
                       {errorMessage}
                     </div>
                   )}
@@ -687,19 +842,30 @@ export default function MVPLandingPage({ variant }: MVPLandingPageProps) {
                   <button
                     type="submit"
                     disabled={formStatus === "submitting"}
-                    className="mvp-cta-btn w-full py-4 text-white text-lg font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none disabled:shadow-none"
+                    className="mvp-cta-btn w-full py-4 text-white text-lg font-semibold rounded-xl disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none"
                   >
-                    {formStatus === "submitting" ? (
-                      <span className="inline-flex items-center gap-2">
+                    <span className="mvp-cta-content">
+                      {/* Idle label — fades + blurs out when submitting */}
+                      <span
+                        className="mvp-cta-layer"
+                        data-stacked="true"
+                        data-hidden={formStatus === "submitting" ? "true" : "false"}
+                      >
+                        {variant.form.submitText}
+                      </span>
+                      {/* Spinner overlay — fades + sharpens in */}
+                      <span
+                        className="mvp-cta-layer inline-flex items-center gap-2"
+                        data-hidden={formStatus === "submitting" ? "false" : "true"}
+                        aria-hidden={formStatus !== "submitting"}
+                      >
                         <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
                           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                         </svg>
                         Submitting...
                       </span>
-                    ) : (
-                      variant.form.submitText
-                    )}
+                    </span>
                   </button>
 
                   <p className="text-center text-sm text-[#475569]">


### PR DESCRIPTION
## Summary

Five-phase animation/feel refresh across doug.is. Theme stays the same — only the motion language changes. Built on the Emil Kowalski design-engineering principles: strong custom curves, durations under 300ms for UI, press feedback on every clickable surface, real reduced-motion support.

| # | Phase | Highlights |
| --- | --- | --- |
| 1 | Motion-token foundation | `--ease-*` and `--dur-*` tokens, `prefers-reduced-motion` baseline, button/card system gains `:active` press feedback and hover-media-query gating |
| 2 | Header & hero choreography | iOS-style mobile drawer curve, hero stagger entrance, scroll parallax moved off the React render path, TerminalText rewritten to skip ~600 React renders per page load |
| 3 | /building/mvp landing | scroll-reveal hook with section staggers, FAQ accordion uses the `grid-template-rows: 0fr → 1fr` trick, CTA submit blur-crossfade, success state entrance with checkmark overshoot |
| 4 | Public pages | tighter hover tempos on Thinking/Building cards, ContactForm focus transitions, Investing quote flicker fixed with mount-aware fade-in |
| 5 | Admin | every `transition: all` replaced with property lists, `:active` press feedback, drawer uses `--ease-drawer` |

Every component now pulls from a single set of motion tokens, so the site sings in the same key.

### What was deliberately left alone

- No theme changes. Navy/amber palette, fonts, layout, copy all unchanged.
- No new dependencies. Pure CSS + existing React refs. No Framer Motion.
- No homepage redesign.

## Test plan

- [ ] Hover/press every primary and secondary button; expect subtle lift on hover, scale(0.97) on press
- [ ] On a touch device, tap a card — confirm no phantom hover state lingers
- [ ] Open the homepage and watch the hero stagger in (terminal → photo → headline → copy → buttons)
- [ ] Scroll the homepage; hexagons should parallax smoothly without dropping frames
- [ ] Open mobile menu — drawer slides with iOS curve, links fade up in cascade
- [ ] Visit /building/mvp; sections reveal as you scroll with internal stagger
- [ ] Click a FAQ question; expect smooth auto-height open without drag-then-snap
- [ ] Submit the MVP form; confirm text → spinner crossfades cleanly, success state scales in
- [ ] Visit /investing; navigate away and back — no flash of `quotes[0]` before the random quote
- [ ] Focus a ContactForm input; ring fades in instead of appearing abruptly
- [ ] Toggle OS-level reduced-motion; confirm transforms disappear, opacity transitions remain
- [ ] Spot-check /admin; mobile sidebar uses the new drawer curve

🤖 Generated with [Claude Code](https://claude.com/claude-code)